### PR TITLE
Validate theorem_name in lean_verify to prevent Lean command injection

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1154,6 +1154,7 @@ def verify_theorem(
     """Check theorem axioms + optional source scan. Only scans the given file, not imports."""
     from lean_lsp_mcp.verify import (
         check_axiom_errors,
+        is_valid_theorem_name,
         parse_axioms,
         scan_warnings,
     )
@@ -1163,6 +1164,10 @@ def verify_theorem(
         _raise_invalid_path(file_path)
 
     abs_path = Path(file_path)
+    if not is_valid_theorem_name(theorem_name):
+        raise LeanToolError(
+            "Invalid theorem_name: expected a fully qualified Lean identifier"
+        )
     client: LeanLSPClient = ctx.request_context.lifespan_context.client
     client.open_file(rel_path)
 

--- a/src/lean_lsp_mcp/verify.py
+++ b/src/lean_lsp_mcp/verify.py
@@ -26,6 +26,14 @@ _WARNING_PATTERNS: list[str] = [
 ]
 
 _COMBINED_PATTERN = "|".join(f"(?:{p})" for p in _WARNING_PATTERNS)
+_LEAN_QUALIFIED_NAME_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z_][A-Za-z0-9_']*)*$"
+)
+
+
+def is_valid_theorem_name(theorem_name: str) -> bool:
+    """Return True for a simple, fully-qualified Lean identifier."""
+    return bool(_LEAN_QUALIFIED_NAME_RE.fullmatch(theorem_name))
 
 
 def parse_axioms(diagnostics: list[dict]) -> list[str]:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -106,3 +106,21 @@ async def test_verify_nonexistent_theorem(
             expect_error=True,
         )
         assert result.isError
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_injected_theorem_name(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    test_project_path: Path,
+) -> None:
+    verify_file = test_project_path / "VerifyTest.lean"
+    async with mcp_client_factory() as client:
+        result = await client.call_tool(
+            "lean_verify",
+            {
+                "file_path": str(verify_file),
+                "theorem_name": "verify_clean\n#eval IO.println 1",
+            },
+            expect_error=True,
+        )
+        assert result.isError

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -9,6 +9,7 @@ import pytest
 
 from lean_lsp_mcp.verify import (
     check_axiom_errors,
+    is_valid_theorem_name,
     parse_axioms,
     scan_warnings,
 )
@@ -101,3 +102,17 @@ class TestScanWarnings:
 
     def test_nonexistent(self, tmp_path: Path):
         assert scan_warnings(tmp_path / "nope.lean") == []
+
+
+class TestIsValidTheoremName:
+    def test_accepts_valid_names(self):
+        assert is_valid_theorem_name("verify_clean")
+        assert is_valid_theorem_name("Namespace.verify_clean")
+        assert is_valid_theorem_name("Ns.sub.theorem_name'")
+
+    def test_rejects_invalid_names(self):
+        assert not is_valid_theorem_name("")
+        assert not is_valid_theorem_name("0foo")
+        assert not is_valid_theorem_name("Foo\n#eval IO.println 1")
+        assert not is_valid_theorem_name("Foo bar")
+        assert not is_valid_theorem_name("Foo..bar")


### PR DESCRIPTION
### Motivation
- Prevent command injection from attacker-controlled `theorem_name` which was interpolated into a temporary Lean snippet and could include newlines/directives (e.g. `#eval`) that the LSP would execute.  
- Provide a minimal, conservative fix that blocks malformed or multi-line names while preserving the intended verification behavior for normal fully-qualified names.

### Description
- Add a strict validator `is_valid_theorem_name` (regex-based) in `src/lean_lsp_mcp/verify.py` that accepts only simple fully-qualified Lean identifiers (segments starting with a letter/underscore followed by alphanumerics/underscore/prime, separated by dots).  
- Use `is_valid_theorem_name` in `src/lean_lsp_mcp/server.py` inside `verify_theorem` to reject invalid `theorem_name` inputs early and raise a `LeanToolError` with a clear message.  
- Add unit tests in `tests/unit/test_verify.py` to cover valid and invalid theorem names and an integration test in `tests/test_verify.py` to assert that `lean_verify` rejects an injected newline/#eval payload.  
- The change is minimal and only blocks unsafe identifiers; normal fully-qualified names are still accepted and verification proceeds unchanged.

### Testing
- Compiled relevant modules with `python -m py_compile src/lean_lsp_mcp/verify.py src/lean_lsp_mcp/server.py tests/unit/test_verify.py tests/test_verify.py`, which succeeded.  
- Ran `pytest -q tests/unit/test_verify.py tests/test_verify.py` but the run failed to start due to an environment dependency error (`ModuleNotFoundError: No module named 'mcp'`) in test harness setup, so full test execution was not possible in this environment.  
- Performed local sanity checks during development (added tests and ensured no syntax errors); the added tests exercise the validator and the integration rejection behavior when the test harness is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4fd302788325812dfbd77312553b)