### PR TITLE
fix: restore project-root path enforcement

### DIFF
--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -7,7 +7,7 @@ from mcp.server.fastmcp.utilities.logging import get_logger
 from leanclient import LeanLSPClient
 
 from lean_lsp_mcp.file_utils import get_relative_file_path
-from lean_lsp_mcp.utils import OutputCapture
+from lean_lsp_mcp.utils import LeanToolError, OutputCapture
 
 
 logger = get_logger(__name__)
@@ -61,7 +61,11 @@ def startup_client(ctx: Context):
 
 
 def resolve_file_path(
-    ctx: Context, file_path: str, *, require_exists: bool = True
+    ctx: Context,
+    file_path: str,
+    *,
+    require_exists: bool = True,
+    enforce_project_root: bool = True,
 ) -> Path:
     """Resolve a file path with support for project-root-relative inputs.
 
@@ -78,6 +82,15 @@ def resolve_file_path(
         resolved = (project_root / path_obj).resolve()
     else:
         resolved = path_obj.resolve()
+
+    if enforce_project_root and project_root is not None:
+        project_root = project_root.resolve()
+        try:
+            resolved.relative_to(project_root)
+        except ValueError as exc:
+            raise LeanToolError(
+                f"Path '{resolved}' is outside the configured Lean project root '{project_root}'."
+            ) from exc
 
     if require_exists and not resolved.exists():
         raise FileNotFoundError(str(resolved))
@@ -121,7 +134,14 @@ def infer_project_path(file_path: str, ctx: Context | None = None) -> Path | Non
         if not hasattr(lifespan, "project_cache"):
             lifespan.project_cache = {}
 
-    abs_file_path = str(resolve_file_path(ctx, file_path, require_exists=False))
+    abs_file_path = str(
+        resolve_file_path(
+            ctx,
+            file_path,
+            require_exists=False,
+            enforce_project_root=False,
+        )
+    )
     file_dir = os.path.dirname(abs_file_path)
 
     def set_project_path(project_path: Path, cache_dirs: list[str]) -> Path | None:
@@ -171,7 +191,7 @@ def infer_project_path(file_path: str, ctx: Context | None = None) -> Path | Non
 def setup_client_for_file(ctx: Context, file_path: str) -> str | None:
     """Ensure the LSP client matches the file's Lean project and return its relative path."""
     try:
-        resolved_file = str(resolve_file_path(ctx, file_path))
+        resolved_file = str(resolve_file_path(ctx, file_path, enforce_project_root=False))
     except (FileNotFoundError, OSError):
         return None
 

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -506,14 +506,15 @@ async def lsp_build(
     if not lean_project_path:
         lean_project_path_obj = configured_root
     else:
-        lean_project_path_obj = Path(lean_project_path).resolve()
+        lean_project_path_obj = resolve_file_path(
+            ctx, lean_project_path, require_exists=False
+        )
         lifespan.lean_project_path = lean_project_path_obj
 
     if lean_project_path_obj is None:
         raise LeanToolError(
             "Lean project path not known yet. Provide `lean_project_path` explicitly or call another tool first."
         )
-
     async def build_factory() -> BuildResult:
         return await _run_build(ctx, lean_project_path_obj, clean, output_lines)
 

--- a/tests/unit/test_build_progress.py
+++ b/tests/unit/test_build_progress.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lean_lsp_mcp.server import lsp_build
+from lean_lsp_mcp.utils import LeanToolError
 
 
 class _FailingClient:
@@ -164,3 +166,19 @@ async def test_lsp_build_continues_when_client_close_fails(build_mocks, patch_bu
     assert failing_client.close_calls == 1
     assert result.success
     assert ctx.request_context.lifespan_context.client is not failing_client
+
+
+@pytest.mark.asyncio
+async def test_lsp_build_rejects_path_outside_configured_root(tmp_path: Path):
+    ctx = MagicMock()
+    project = tmp_path / "proj"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    ctx.request_context.lifespan_context.lean_project_path = project
+    ctx.request_context.lifespan_context.client = None
+    ctx.request_context.lifespan_context.build_coordinator = None
+
+    with pytest.raises(LeanToolError, match="outside the configured Lean project"):
+        await lsp_build(ctx, lean_project_path=str(outside))

--- a/tests/unit/test_client_utils.py
+++ b/tests/unit/test_client_utils.py
@@ -11,6 +11,7 @@ from lean_lsp_mcp.client_utils import (
     startup_client,
     valid_lean_project_path,
 )
+from lean_lsp_mcp.utils import LeanToolError
 
 
 class _MockLeanClient:
@@ -248,3 +249,31 @@ def test_resolve_file_path_uses_project_root_for_relative(tmp_path: Path) -> Non
     ctx = _Context(_LifespanContext(project, None))
     resolved = resolve_file_path(ctx, "src/Example.lean")
     assert resolved == target.resolve()
+
+
+def test_resolve_file_path_rejects_absolute_path_outside_project_root(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    outside = tmp_path / "secrets.txt"
+    outside.write_text("secret")
+
+    ctx = _Context(_LifespanContext(project, None))
+
+    with pytest.raises(LeanToolError, match="outside the configured Lean project"):
+        resolve_file_path(ctx, str(outside))
+
+
+def test_resolve_file_path_rejects_relative_escape_outside_project_root(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    outside = tmp_path / "outside.lean"
+    outside.write_text("theorem t : True := by trivial")
+
+    ctx = _Context(_LifespanContext(project, None))
+
+    with pytest.raises(LeanToolError, match="outside the configured Lean project"):
+        resolve_file_path(ctx, "../outside.lean")


### PR DESCRIPTION
### Motivation

- A refactor removed strict project-root checks so `resolve_file_path` accepted arbitrary absolute paths and `lsp_build` could set the active root to any path, enabling untrusted clients to read files or trigger builds outside the configured project.  
- The change restores containment checks to prevent file disclosure and unintended builds while preserving internal project-discovery flows that must inspect other paths.

### Description

- Reintroduced project-root containment enforcement in `resolve_file_path` by default, raising `LeanToolError` when a resolved path is outside the configured `lean_project_path` (while keeping an escape hatch).  
- Added an `enforce_project_root` parameter to `resolve_file_path` (default `True`) so internal callers can bypass enforcement when performing project discovery.  
- Updated `infer_project_path` and `setup_client_for_file` to call `resolve_file_path(..., enforce_project_root=False)` so project discovery and client switching continue to work.  
- Updated `lsp_build` to resolve any explicit `lean_project_path` via the shared `resolve_file_path` validation (using `require_exists=False`) so builds cannot silently switch to directories outside the configured project root.

### Testing

- Installed dev dependencies with `python -m pip install -e '.[dev]'` which completed successfully.  
- Ran unit tests `pytest tests/unit/test_client_utils.py tests/unit/test_build_progress.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd266d96608325b63d1720c64f1717)